### PR TITLE
add isort/flake8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,9 +13,7 @@ matrix:
     python: "3.6"
     script:
       - ./scripts/copyright_line_check.sh
-      - pylint --rcfile=.pylintrc bubs
-      - pydocstyle --config=.pydocstyle_test bubs
-      - pydocstyle --config=.pydocstyle bubs
+      - ./scripts/lint.sh
   - name: "Python 3.6 unit tests"
     python: "3.6"
     script:

--- a/bubs/embedding_layer.py
+++ b/bubs/embedding_layer.py
@@ -236,6 +236,6 @@ class ContextualizedEmbedding(Layer):
             "forward_lstm_weights": self._forward_lstm_weights,
             "backward_lstm_weights": self._backward_lstm_weights,
             "char_embed_weights_forward": self._char_embeddings_forward,
-            "char_embed_weights_back":  self._char_embeddings_backward
+            "char_embed_weights_back": self._char_embeddings_backward
         })
         return base_config

--- a/bubs/helpers.py
+++ b/bubs/helpers.py
@@ -218,7 +218,7 @@ class InputEncoder:
         for i in range(batch_size):
             clipped_len = min(len(index_list[i]), pad_len)
             padded_sentences[i, :, 0] = i
-            padded_sentences[i, pad_len - clipped_len :, 1] = index_list[i][:clipped_len]
+            padded_sentences[i, pad_len - clipped_len:, 1] = index_list[i][:clipped_len]
         return padded_sentences
 
     def _prepare_mask_array(self, index_list):
@@ -227,7 +227,7 @@ class InputEncoder:
         batch_size = len(index_list)
         mask = np.zeros((batch_size, pad_len))
         for i, inds in enumerate(index_list):
-            mask[i, pad_len - len(inds) :] = 1
+            mask[i, pad_len - len(inds):] = 1
         return mask
 
     def _encode_and_get_output_index_list(self, token_list, span_list):

--- a/bubs/tests/test_embedding_layer.py
+++ b/bubs/tests/test_embedding_layer.py
@@ -8,9 +8,7 @@ from keras.optimizers import Adam
 import numpy as np
 
 from ..embedding_layer import (
-    ContextualizedEmbedding,
-    load_weights_from_npz,
-    make_lstm_weights_for_keras,
+    ContextualizedEmbedding, load_weights_from_npz, make_lstm_weights_for_keras
 )
 from ..helpers import InputEncoder
 
@@ -63,12 +61,10 @@ class TestEmbeddingLayer(unittest.TestCase):
         )
         cls.model.compile(optimizer=Adam(), loss="categorical_crossentropy")
 
-
     def test_default_weights(self):
         # check that default weights get loaded ok
         weights = load_weights_from_npz()
         context_embedding_layer = ContextualizedEmbedding(self.max_token_seq_len, weights)  # noqa
-
 
     def test_custom_layer(self):
         """Build a dummy Keras model using the custom layer. Check the output dimensions."""

--- a/bubs/tests/test_helpers.py
+++ b/bubs/tests/test_helpers.py
@@ -5,16 +5,10 @@ import funcy
 import numpy as np
 
 from ..helpers import (
-    InputEncoder,
-    _align_sentence_spans_for_long_sentences,
-    _check_token_spans,
-    _pad_sentences,
-    _reverse_inputs_and_indices,
-    _shift_spans_to_start_at_zero,
-    _split_long_sentences,
-    create_document_indices_from_sentence_indices,
-    get_space_joined_indices_from_token_lists,
-    split_sentences_and_tokenize_raw_text,
+    InputEncoder, _align_sentence_spans_for_long_sentences, _check_token_spans, _pad_sentences,
+    _reverse_inputs_and_indices, _shift_spans_to_start_at_zero, _split_long_sentences,
+    create_document_indices_from_sentence_indices, get_space_joined_indices_from_token_lists,
+    split_sentences_and_tokenize_raw_text
 )
 
 
@@ -874,7 +868,7 @@ class TestHelpers(unittest.TestCase):
         # check that tokens are actually in the raw_text at the correct locations
         for idx_list, token_list in zip(document_indices, tokens):
             for span, token in zip(idx_list, token_list):
-                self.assertEqual(token, raw_text[span[0] : span[1]])
+                self.assertEqual(token, raw_text[span[0]: span[1]])
 
         # Test for document that starts with white space - make sure document spans are
         # appropriately shifted

--- a/bubs/tokenizer.py
+++ b/bubs/tokenizer.py
@@ -28,7 +28,7 @@ def _html_tokenize(sentence):
 
 
 class RegexTokenizer:
-    """Fast regex-based tokenizer, wrapping around https://github.com/fnl/segtok """
+    """Fast regex-based tokenizer, wrapping around https://github.com/fnl/segtok ."""
 
     def __init__(self, max_characters_per_token=None):
         """Set up tokenizer specific flags.

--- a/bubs/tokenizer.py
+++ b/bubs/tokenizer.py
@@ -2,10 +2,7 @@
 import funcy
 from segtok.segmenter import split_single, to_unix_linebreaks
 from segtok.tokenizer import (
-    split_contractions,
-    split_possessive_markers,
-    web_tokenizer,
-    word_tokenizer,
+    split_contractions, split_possessive_markers, web_tokenizer, word_tokenizer
 )
 
 

--- a/bubs/tokenizer.py
+++ b/bubs/tokenizer.py
@@ -28,7 +28,7 @@ def _html_tokenize(sentence):
 
 
 class RegexTokenizer:
-    """Fast regex-based tokenizer, wrapping around https://github.com/fnl/segtok ."""
+    """Fast regex-based tokenizer, wrapping around https://github.com/fnl/segtok """
 
     def __init__(self, max_characters_per_token=None):
         """Set up tokenizer specific flags.

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -7,3 +7,4 @@ pytest-cov
 segtok>=1.5.7
 tensorflow==1.13.1
 pydocstyle>=4.0.0,<5
+isort>=4.0.0,<5

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -8,3 +8,4 @@ segtok>=1.5.7
 tensorflow==1.13.1
 pydocstyle>=4.0.0,<5
 isort>=4.0.0,<5
+flake8>=3.0.0,<4

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+pylint --rcfile=.pylintrc bubs
+pydocstyle --config=.pydocstyle_test bubs
+pydocstyle --config=.pydocstyle bubs
+isort --recursive --diff bubs
+flake8 --config=setup.cfg bubs

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
+err=0
+trap 'err=1' ERR
 pylint --rcfile=.pylintrc bubs
 pydocstyle --config=.pydocstyle_test bubs
 pydocstyle --config=.pydocstyle bubs
 isort --recursive --diff bubs
 flake8 --config=setup.cfg bubs
+test $err = 0 # Return non-zero if any command failed


### PR DESCRIPTION
turns on isort and flake8
adds a bash script to run all lint commands at once for ease
bash script needs to watch for ERR and then exit with status1 if it sees any... without that, if a non-terminal step fails it wont fail on travisci (as long as the last command exits with status 0)