### PR TITLE
change keras to tf.keras

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,3 +3,6 @@
 Initial release.
 ###v0.0.2
 Add `from_config()` function to the ContextualizedEmbedding object, which is called on deserialization. It turns pickled lists of lists back into original numpy arrays.
+###v0.1.0
+Change to `tf.keras` instead of keras because it's the future of keras and makes tensorflow version irrelevant.
+

--- a/bubs/__init__.py
+++ b/bubs/__init__.py
@@ -1,4 +1,4 @@
 # Copyright 2019 Kensho Technologies, LLC.
-__version__ = "0.0.2"
+__version__ = "0.1.0"
 
 from .embedding_layer import ContextualizedEmbedding, load_weights_from_npz  # noqa

--- a/bubs/embedding_layer.py
+++ b/bubs/embedding_layer.py
@@ -1,9 +1,10 @@
 # Copyright 2019 Kensho Technologies, LLC.
 import os
 
-import keras.backend as K
-from keras.layers import LSTM, Embedding, Lambda, Layer
+
 import numpy as np
+import tensorflow as tf
+from tensorflow.keras.layers import LSTM, Embedding, Lambda, Layer
 
 from .char_to_int import CHAR_TO_INT
 
@@ -98,7 +99,7 @@ def batch_indexing(inputs):
     embeddings, indices = inputs
     # this will break on deserialization if we simply import tensorflow
     # we have to use keras.backend.tf instead of tensorflow
-    return K.tf.gather_nd(embeddings, indices)
+    return tf.gather_nd(embeddings, indices)
 
 
 def multiply(inputs):
@@ -114,7 +115,7 @@ def multiply(inputs):
     x, y = inputs
     # this will break on deserialization if we simply import tensorflow
     # we have to use keras.backend.tf instead of tensorflow
-    return K.tf.einsum("ijk,ij->ijk", x, y)
+    return tf.einsum("ijk,ij->ijk", x, y)
 
 
 class ContextualizedEmbedding(Layer):

--- a/bubs/embedding_layer.py
+++ b/bubs/embedding_layer.py
@@ -1,7 +1,6 @@
 # Copyright 2019 Kensho Technologies, LLC.
 import os
 
-
 import numpy as np
 import tensorflow as tf
 from tensorflow.keras.layers import LSTM, Embedding, Lambda, Layer

--- a/bubs/tests/test_embedding_layer.py
+++ b/bubs/tests/test_embedding_layer.py
@@ -2,10 +2,10 @@
 import os
 import unittest
 
-from keras.layers import Input
-from keras.models import Model
-from keras.optimizers import Adam
 import numpy as np
+from tensorflow.keras.layers import Input
+from tensorflow.keras.models import Model
+from tensorflow.keras.optimizers import Adam
 
 from ..embedding_layer import (
     ContextualizedEmbedding, load_weights_from_npz, make_lstm_weights_for_keras

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -5,7 +5,6 @@ pylint>=2.4.0,<3
 pytest
 pytest-cov
 segtok>=1.5.7
-tensorflow==1.13.1
 pydocstyle>=4.0.0,<5
 isort>=4.0.0,<5
 flake8>=3.0.0,<4

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -8,3 +8,4 @@ segtok>=1.5.7
 pydocstyle>=4.0.0,<5
 isort>=4.0.0,<5
 flake8>=3.0.0,<4
+tensorflow>=1.13

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ def find_long_description():
     return read_file('../README.md')
 
 
-REQUIRED_PACKAGES = ["funcy>=1.10", "Keras==2.2.4", "numpy>=1.10.0", "segtok>=1.5.7"]
+REQUIRED_PACKAGES = ["funcy>=1.10", "numpy>=1.10.0", "segtok>=1.5.7", "tensorflow>=1.13"]
 
 setup(
     name=PACKAGE_NAME,


### PR DESCRIPTION
Changing to `tf.keras` is the accepted future of keras. It prevents compatibility issues between tensorflow and keras, and makes migrating to tf2.0 easy. 

Tested with `tensorflow==2.3.0` and `==1.15`